### PR TITLE
Edit valid

### DIFF
--- a/src/features/OrderEditDrawer/OrderEditDrawer.tsx
+++ b/src/features/OrderEditDrawer/OrderEditDrawer.tsx
@@ -97,7 +97,12 @@
             />
           </FloatButton.Group>
 
-          <Form layout="vertical" form={form} initialValues={selectedOrder}>
+          <Form
+            layout="vertical"
+            form={form}
+            initialValues={selectedOrder}
+            onValuesChange={form.getFieldValue('onValuesChange')}
+          >
             <Row gutter={16}>
               <Col span={8}>
                 <Form.Item label="進捗" name="progress">

--- a/src/features/OrderEditDrawer/OrderEditDrawer.tsx
+++ b/src/features/OrderEditDrawer/OrderEditDrawer.tsx
@@ -194,7 +194,7 @@
 
             <Row gutter={16}>
               <Col span={8}>
-                <Form.Item label="ロット" name="lot">
+                <Form.Item label="ロット/シリアル" name="lot">
                   <Input placeholder="ロットを入力" />
                 </Form.Item>
               </Col>

--- a/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
+++ b/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
@@ -27,6 +27,7 @@ const validateProgress = (progress: number, values: any, dates: DatesType, form:
         message.error('希望納期 または 注文書Noが入っていません。');
         return false;
       }
+      dates.order_date = updateDateIfEmpty(dates.order_date, '受注日', form);
       break;
     case PROGRESS_ESTIMATE:
       if (!values.estimate_code || !values.amount) {

--- a/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
+++ b/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
@@ -5,105 +5,97 @@ import { OrderListDataType } from '@/types/types';
 import { DatesType } from '../types/types';
 import dayjs from 'dayjs';
 
+const PROGRESS_DESIRED_DELIVERY = 3;
+const PROGRESS_ESTIMATE = 4;
+const PROGRESS_SHIPMENT = 5;
+const PROGRESS_ACCEPTANCE = 7;
+
+const updateDateIfEmpty = (currentDate: string | null, fieldName: string, form: any) => {
+  if (!currentDate) {
+    const today = dayjs().format('YYYY-MM-DD');
+    form.setFieldsValue({ [fieldName]: today });
+    message.info(`${fieldName}に本日の日付を自動登録しました。`);
+    return today;
+  }
+  return currentDate;
+};
+
+const validateProgress = (progress: number, values: any, dates: DatesType, form: any) => {
+  switch (progress) {
+    case PROGRESS_DESIRED_DELIVERY:
+      if (!dates.desired_delivery_date || !values.order_form_code) {
+        message.error('希望納期 または 注文書Noが入っていません。');
+        return false;
+      }
+      break;
+    case PROGRESS_ESTIMATE:
+      if (!values.estimate_code || !values.amount) {
+        message.error('見積No, または 金額が入っていません。');
+        return false;
+      }
+      dates.estimate_date = updateDateIfEmpty(dates.estimate_date, '見積日', form);
+      break;
+    case PROGRESS_SHIPMENT:
+      dates.shipment_date = updateDateIfEmpty(dates.shipment_date, '出荷日', form);
+      dates.send_document_date = updateDateIfEmpty(dates.send_document_date, '資料送付日', form);
+      break;
+    case PROGRESS_ACCEPTANCE:
+      dates.accept_date = updateDateIfEmpty(dates.accept_date, '検収日', form);
+      break;
+    default:
+      // Handle other cases or do nothing
+      break;
+  }
+  return true;
+};
+
 export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => void, selectedOrder?: OrderListDataType) => {
   const [form] = Form.useForm();
   const [dates, setDates] = useState<DatesType>({
-    estimate_date: selectedOrder?.estimate_date || null,
-    order_date: selectedOrder?.order_date || null,
-    desired_delivery_date: selectedOrder?.desired_delivery_date || null,
-    shipment_date: selectedOrder?.shipment_date || null,
-    item_receive_date: selectedOrder?.item_receive_date || null,
-    item_return_date: selectedOrder?.item_return_date || null,
-    send_document_date: selectedOrder?.send_document_date || null,
-    receive_document_date: selectedOrder?.receive_document_date || null,
-    accept_date: selectedOrder?.accept_date || null,
+    desired_delivery_date: null,
+    estimate_date: null,
+    shipment_date: null,
+    send_document_date: null,
+    accept_date: null,
+    order_date: null,
+    item_receive_date: null,
+    item_return_date: null,
+    receive_document_date: null,
   });
-
   const [isAttention, setIsAttention] = useState(false);
 
   const handleUpdate = async () => {
-    try {
-      const values = form.getFieldsValue();
-      let newAcceptDate = dates.accept_date;
-      let newShipmentDate = dates.shipment_date;
-      let newSendDocumentDate = dates.send_document_date;
-      let newEstimateDate = dates.estimate_date;
-      let newDesiredDeliveryDate = dates.desired_delivery_date;
+    const values = form.getFieldsValue();
+    if (!validateProgress(values.progress, values, dates, form)) {
+      return;
+    }
 
-      if (values.progress === 3) {
-        if (!newDesiredDeliveryDate || !values.order_form_code) {
-          message.error("希望納期 または 注文書Noが入っていません。");
-          return;
-        }
-      }
+    const mergedData = {
+      ...values,
+      ...dates,
+      attention: isAttention,
+    };
 
-      if (values.progress === 4) {
-        if (!values.estimate_code || !values.amount) {
-          message.error("見積No, または 金額が入っていません。");
-          return;
-        } else if (!newEstimateDate) {
-          newEstimateDate = dayjs().format("YYYY-MM-DD");
-          form.setFieldsValue({ estimate_date: newEstimateDate });
-          message.info("見積日に本日の日付を自動登録しました。");
-        }
-      }
-
-      if (values.progress === 7 && !newAcceptDate) {
-        newAcceptDate = dayjs().format("YYYY-MM-DD");
-        form.setFieldsValue({ accept_date: newAcceptDate });
-        message.info("検収日に本日の日付を自動登録しました。");
-      }
-
-      if (values.progress === 5) {
-        const today = dayjs().format("YYYY-MM-DD");
-        if (!newShipmentDate) {
-          newShipmentDate = today;
-          form.setFieldsValue({ shipment_date: newShipmentDate });
-        }
-        if (!newSendDocumentDate) {
-          newSendDocumentDate = today;
-          form.setFieldsValue({ send_document_date: newSendDocumentDate });
-        }
-        if (!newShipmentDate || !newSendDocumentDate) {
-          message.info("出荷日と資料送付日に本日の日付を自動登録しました。");
-        }
-      }
-
-      const mergedData = {
-        ...values,
-        estimate_date: newEstimateDate,
-        order_date: dates.order_date,
-        desired_delivery_date: newDesiredDeliveryDate,
-        shipment_date: newShipmentDate,
-        item_receive_date: dates.item_receive_date,
-        item_return_date: dates.item_return_date,
-        send_document_date: newSendDocumentDate,
-        receive_document_date: dates.receive_document_date,
-        accept_date: newAcceptDate,
-        attention: isAttention,
-      };
-
-      if (selectedOrder && selectedOrder.id) {
-        const { data, error } = await updateOrder(mergedData, selectedOrder.id);
-
-        if (error) {
-          message.error("注文の更新に失敗しました。");
-        } else {
-          message.success("注文が正常に更新されました。");
-          onClose();
-          refetchOrderList();
-        }
+    if (selectedOrder && selectedOrder.id) {
+      const { data, error } = await updateOrder(mergedData, selectedOrder.id);
+      if (error) {
+        message.error('注文の更新に失敗しました。');
       } else {
-        message.error("注文が選択されていないか、IDが不足しています。");
+        message.success('注文が正常に更新されました。');
+        onClose();
+        refetchOrderList();
       }
-    } catch (err) {
-      message.error("未知のエラーが発生しました。");
+    } else {
+      message.error('注文が選択されていないか、IDが不足しています。');
     }
   };
 
-  form.setFieldsValue(selectedOrder);
-  form.setFieldsValue(dates);
-  form.setFieldsValue({ attention: isAttention });
+  // Set initial form values
+  if (selectedOrder) {
+    form.setFieldsValue(selectedOrder);
+    form.setFieldsValue(dates);
+    form.setFieldsValue({ attention: isAttention });
+  }
 
   return {
     form,

--- a/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
+++ b/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
@@ -27,8 +27,26 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
       let newAcceptDate = dates.accept_date;
       let newShipmentDate = dates.shipment_date;
       let newSendDocumentDate = dates.send_document_date;
-      let shipmentDateUpdated = false;
-      let sendDocumentDateUpdated = false;
+      let newEstimateDate = dates.estimate_date;
+      let newDesiredDeliveryDate = dates.desired_delivery_date;
+
+      if (values.progress === 3) {
+        if (!newDesiredDeliveryDate || !values.order_form_code) {
+          message.error("希望納期 または 注文書Noが入っていません。");
+          return;
+        }
+      }
+
+      if (values.progress === 4) {
+        if (!values.estimate_code || !values.amount) {
+          message.error("見積No, または 金額が入っていません。");
+          return;
+        } else if (!newEstimateDate) {
+          newEstimateDate = dayjs().format("YYYY-MM-DD");
+          form.setFieldsValue({ estimate_date: newEstimateDate });
+          message.info("見積日に本日の日付を自動登録しました。");
+        }
+      }
 
       if (values.progress === 7 && !newAcceptDate) {
         newAcceptDate = dayjs().format("YYYY-MM-DD");
@@ -41,27 +59,21 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
         if (!newShipmentDate) {
           newShipmentDate = today;
           form.setFieldsValue({ shipment_date: newShipmentDate });
-          shipmentDateUpdated = true;
         }
         if (!newSendDocumentDate) {
           newSendDocumentDate = today;
           form.setFieldsValue({ send_document_date: newSendDocumentDate });
-          sendDocumentDateUpdated = true;
         }
-        if (shipmentDateUpdated && sendDocumentDateUpdated) {
+        if (!newShipmentDate || !newSendDocumentDate) {
           message.info("出荷日と資料送付日に本日の日付を自動登録しました。");
-        } else if (shipmentDateUpdated) {
-          message.info("出荷日に本日の日付を自動登録しました。");
-        } else if (sendDocumentDateUpdated) {
-          message.info("資料送付日に本日の日付を自動登録しました。");
         }
       }
 
       const mergedData = {
         ...values,
-        estimate_date: dates.estimate_date,
+        estimate_date: newEstimateDate,
         order_date: dates.order_date,
-        desired_delivery_date: dates.desired_delivery_date,
+        desired_delivery_date: newDesiredDeliveryDate,
         shipment_date: newShipmentDate,
         item_receive_date: dates.item_receive_date,
         item_return_date: dates.item_return_date,

--- a/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
+++ b/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
@@ -20,9 +20,20 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
 
   const [isAttention, setIsAttention] = useState(false);
 
+  const onFormValuesChange = (changedValues: any, allValues: any) => {
+    if ('progress' in changedValues) {
+      console.log('Progress changed to:', changedValues.progress);
+    }
+  };
+
   const handleUpdate = async () => {
     try {
       const values = form.getFieldsValue();
+
+      if (values.progress === 7) {
+        message.error("進捗が '7' のため、更新処理を停止します。");
+        return;
+      }
 
       const mergedData = {
         ...values,
@@ -57,6 +68,11 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
       message.error("未知のエラーが発生しました。");
     }
   };
+
+  form.setFieldsValue(selectedOrder);
+  form.setFieldsValue(dates);
+  form.setFieldsValue({ attention: isAttention });
+  form.setFieldsValue({ onValuesChange: onFormValuesChange });
 
   return {
     form,


### PR DESCRIPTION
## 概要
案件編集画面のバリデーション周りを実装
* 項目「見積提出」に変更時「見積日」「見積No」「金額」
*「受注済」変更時「受注日」「希望納期」「注文書No」
*「検証中」変更時「出荷日」「資料送付日」
* 「完了」であれば「検収日」

それぞれ未入力を弾く、日付関連は当日の日付を自動入力