### PR TITLE
add-updateSet

### DIFF
--- a/src/features/Dashboard/AreaChart.tsx
+++ b/src/features/Dashboard/AreaChart.tsx
@@ -33,7 +33,7 @@ export const AreaChartPage: React.FC<AreaChartPageProps> = ({ selectedDateRange 
       const groupedByOrderDate: GroupedData = orderData.reduce((acc: GroupedData, curr: OrderListDataType) => {
         if (curr.order_date) {
           const month = dayjs(curr.order_date).format('YYYY-MM');
-          acc[month] = (acc[month] || 0) + parseFloat(curr.amount || '0');
+          acc[month] = (acc[month] || 0) + parseFloat(curr.amount ? curr.amount.toString() : '0');
         }
         return acc;
       }, {});
@@ -41,7 +41,7 @@ export const AreaChartPage: React.FC<AreaChartPageProps> = ({ selectedDateRange 
       const groupedByAcceptDate: GroupedData = orderData.reduce((acc: GroupedData, curr: OrderListDataType) => {
         if (curr.accept_date) {
           const month = dayjs(curr.accept_date).format('YYYY-MM');
-          acc[month] = (acc[month] || 0) + parseFloat(curr.amount || '0');
+          acc[month] = (acc[month] || 0) + parseFloat(curr.amount ? curr.amount.toString() : '0');
         }
         return acc;
       }, {});
@@ -49,7 +49,7 @@ export const AreaChartPage: React.FC<AreaChartPageProps> = ({ selectedDateRange 
       const salesByCompleted: GroupedData = completedRecords.reduce((acc: GroupedData, curr: OrderListDataType) => {
         if (curr.order_date) {
           const month = dayjs(curr.order_date).format('YYYY-MM');
-          acc[month] = (acc[month] || 0) + parseFloat(curr.amount || '0');
+          acc[month] = (acc[month] || 0) + parseFloat(curr.amount ? curr.amount.toString() : '0');
         }
         return acc;
       }, {});

--- a/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
+++ b/src/features/OrderEditDrawer/hooks/useOrderUpdater.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Form, message } from 'antd';
 import { updateOrder } from '../orderService';
 import { OrderListDataType } from '@/types/types';
@@ -64,6 +64,13 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
     receive_document_date: null,
   });
   const [isAttention, setIsAttention] = useState(false);
+  const [initialProgress, setInitialProgress] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (selectedOrder) {
+      setInitialProgress(selectedOrder.progress);
+    }
+  }, [selectedOrder]);
 
   const handleUpdate = async () => {
     const values = form.getFieldsValue();
@@ -71,10 +78,13 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
       return;
     }
 
+    const statusUpdatedDate = values.progress !== initialProgress ? dayjs().format('YYYY-MM-DD') : selectedOrder?.status_updated_at;
+
     const mergedData = {
       ...values,
       ...dates,
       attention: isAttention,
+      status_updated_at: statusUpdatedDate,
     };
 
     if (selectedOrder && selectedOrder.id) {
@@ -105,5 +115,7 @@ export const useOrderUpdater = (onClose: () => void, refetchOrderList: () => voi
     setDates,
     handleUpdate,
     setIsAttention,
+    initialProgress,
+    setInitialProgress,
   };
 };

--- a/src/pages/api/notifyStatusUpdates.js
+++ b/src/pages/api/notifyStatusUpdates.js
@@ -25,7 +25,7 @@ export default async function notifyStatusUpdates(req, res) {
       .select('prefix, order_code, progress')
       .not('status_updated_at', 'is', null)
       .lte('status_updated_at', oneMonthAgo.toISOString())
-      .not('progress', 'in', '(6,7)'); // 修正箇所: 配列ではなく文字列で範囲を指定
+      .not('progress', 'in', '(6,7)');
       if (orderError) throw orderError;
 
     // progressごとにグループ化し、sort順に並び替えてステータス名で表示

--- a/src/types/database.types.ts
+++ b/src/types/database.types.ts
@@ -56,6 +56,7 @@ export interface Database {
           {
             foreignKeyName: "customer_department_customer_id_fkey"
             columns: ["customer_id"]
+            isOneToOne: false
             referencedRelation: "customer"
             referencedColumns: ["id"]
           }
@@ -114,12 +115,14 @@ export interface Database {
           {
             foreignKeyName: "item_return_return_orderlist_id_fkey"
             columns: ["return_orderlist_id"]
+            isOneToOne: false
             referencedRelation: "order_list"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "item_return_return_orderlist_id_fkey"
             columns: ["return_orderlist_id"]
+            isOneToOne: false
             referencedRelation: "order_list_extended"
             referencedColumns: ["id"]
           }
@@ -128,7 +131,7 @@ export interface Database {
       order_list: {
         Row: {
           accept_date: string | null
-          amount: string | null
+          amount: number | null
           attention: boolean
           comment: string | null
           created_at: string
@@ -156,14 +159,16 @@ export interface Database {
           progress: number
           quantity: number | null
           receive_document_date: string | null
+          remark: string | null
           request: number
           send_document_date: string | null
           shipment_date: string | null
           soft: string | null
+          status_updated_at: string | null
         }
         Insert: {
           accept_date?: string | null
-          amount?: string | null
+          amount?: number | null
           attention?: boolean
           comment?: string | null
           created_at?: string
@@ -191,14 +196,16 @@ export interface Database {
           progress: number
           quantity?: number | null
           receive_document_date?: string | null
+          remark?: string | null
           request: number
           send_document_date?: string | null
           shipment_date?: string | null
           soft?: string | null
+          status_updated_at?: string | null
         }
         Update: {
           accept_date?: string | null
-          amount?: string | null
+          amount?: number | null
           attention?: boolean
           comment?: string | null
           created_at?: string
@@ -226,45 +233,53 @@ export interface Database {
           progress?: number
           quantity?: number | null
           receive_document_date?: string | null
+          remark?: string | null
           request?: number
           send_document_date?: string | null
           shipment_date?: string | null
           soft?: string | null
+          status_updated_at?: string | null
         }
         Relationships: [
           {
             foreignKeyName: "order_list_customer_department_fkey"
             columns: ["customer_department"]
+            isOneToOne: false
             referencedRelation: "customer_department"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_customer_fkey"
             columns: ["customer"]
+            isOneToOne: false
             referencedRelation: "customer"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_farm_fkey"
             columns: ["farm"]
+            isOneToOne: false
             referencedRelation: "farm"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_priority_fkey"
             columns: ["priority"]
+            isOneToOne: false
             referencedRelation: "priority"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_progress_fkey"
             columns: ["progress"]
+            isOneToOne: false
             referencedRelation: "progress"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_request_fkey"
             columns: ["request"]
+            isOneToOne: false
             referencedRelation: "request"
             referencedColumns: ["id"]
           }
@@ -341,7 +356,7 @@ export interface Database {
       order_list_extended: {
         Row: {
           accept_date: string | null
-          amount: string | null
+          amount: number | null
           attention: boolean | null
           comment: string | null
           created_at: string | null
@@ -374,6 +389,7 @@ export interface Database {
           progress_name: string | null
           quantity: number | null
           receive_document_date: string | null
+          remark: string | null
           request: number | null
           request_name: string | null
           send_document_date: string | null
@@ -384,36 +400,42 @@ export interface Database {
           {
             foreignKeyName: "order_list_customer_department_fkey"
             columns: ["customer_department"]
+            isOneToOne: false
             referencedRelation: "customer_department"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_customer_fkey"
             columns: ["customer"]
+            isOneToOne: false
             referencedRelation: "customer"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_farm_fkey"
             columns: ["farm"]
+            isOneToOne: false
             referencedRelation: "farm"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_priority_fkey"
             columns: ["priority"]
+            isOneToOne: false
             referencedRelation: "priority"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_progress_fkey"
             columns: ["progress"]
+            isOneToOne: false
             referencedRelation: "progress"
             referencedColumns: ["id"]
           },
           {
             foreignKeyName: "order_list_request_fkey"
             columns: ["request"]
+            isOneToOne: false
             referencedRelation: "request"
             referencedColumns: ["id"]
           }
@@ -431,3 +453,83 @@ export interface Database {
     }
   }
 }
+
+export type Tables<
+  PublicTableNameOrOptions extends
+    | keyof (Database["public"]["Tables"] & Database["public"]["Views"])
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+        Database[PublicTableNameOrOptions["schema"]]["Views"])
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
+      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : PublicTableNameOrOptions extends keyof (Database["public"]["Tables"] &
+      Database["public"]["Views"])
+  ? (Database["public"]["Tables"] &
+      Database["public"]["Views"])[PublicTableNameOrOptions] extends {
+      Row: infer R
+    }
+    ? R
+    : never
+  : never
+
+export type TablesInsert<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Insert: infer I
+    }
+    ? I
+    : never
+  : never
+
+export type TablesUpdate<
+  PublicTableNameOrOptions extends
+    | keyof Database["public"]["Tables"]
+    | { schema: keyof Database },
+  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
+    : never = never
+> = PublicTableNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : PublicTableNameOrOptions extends keyof Database["public"]["Tables"]
+  ? Database["public"]["Tables"][PublicTableNameOrOptions] extends {
+      Update: infer U
+    }
+    ? U
+    : never
+  : never
+
+export type Enums<
+  PublicEnumNameOrOptions extends
+    | keyof Database["public"]["Enums"]
+    | { schema: keyof Database },
+  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
+    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
+    : never = never
+> = PublicEnumNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : PublicEnumNameOrOptions extends keyof Database["public"]["Enums"]
+  ? Database["public"]["Enums"][PublicEnumNameOrOptions]
+  : never

--- a/utils/chatwork.ts
+++ b/utils/chatwork.ts
@@ -18,6 +18,8 @@ async function sendChatworkMessage(message: string) {
   });
 
   if (!response.ok) {
+    const errorBody = await response.text();
+    console.error(`Chatwork API error response: ${errorBody}`);
     throw new Error(`Chatwork message send failed: ${response.status}`);
   }
 


### PR DESCRIPTION
## 概要
ステータス更新時、`status_updated_at `カラムに当日の日付を挿入する機能を実装

## 仕様メモ
* ステータス以外の情報が更新されても、ステータスが更新されていなければ`status_updated_at`は更新しない
→あくまでステータスのみにフォーカスする
* 前工程のステータスに変更された場合も日付を更新する
→ステータス変更であれば案件が動いているとみなす
* デフォ値に当日を設定
→案件作成時の日付を格納し、ステータス変化を監視する
