### PR TITLE
set-mon-0800

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/notifyStatusUpdates",
-      "schedule": "0 23 * * 6"
+      "schedule": "0 23 * * 0"
     }
   ]
 }


### PR DESCRIPTION
## 概要
vercel Cron Job実行時間を毎週月曜日AM 8:00に設定
UTC（−9h）で実行されるため実際の設定時刻は日曜の23:00に設定
UIから通知時刻の変更は今後検討